### PR TITLE
Add min and max quantity query params to list items API

### DIFF
--- a/service/static/index.html
+++ b/service/static/index.html
@@ -146,6 +146,18 @@
                 <input type="number" class="form-control" id="item_quantity" placeholder="Enter Item Quantity">
               </div>
             </div>
+            <div class="form-group">
+              <label class="control-label col-sm-2" for="min_item_quantity">Min Quantity:</label>
+              <div class="col-sm-10">
+                <input type="number" class="form-control" id="min_item_quantity" placeholder="Enter Min Item Quantity">
+              </div>
+            </div>
+            <div class="form-group">
+              <label class="control-label col-sm-2" for="max_item_quantity">Max Quantity:</label>
+              <div class="col-sm-10">
+                <input type="number" class="form-control" id="max_item_quantity" placeholder="Enter Max Item Quantity">
+              </div>
+            </div>
 
 
             <!-- SUBMIT BUTTONS -->

--- a/service/static/js/rest_api.js
+++ b/service/static/js/rest_api.js
@@ -540,11 +540,25 @@ $(function () {
         let customer_id = $("#item_customer_id").val();
         let item_id = $("#item_item_id").val();
         let quantity = $("#item_quantity").val();
+        let min_quantity = $("#min_item_quantity").val();
+        let max_quantity = $("#max_item_quantity").val();
 
         let queryString = ""
 
         if (quantity) {
             queryString += 'quantity=' + quantity
+        }
+        if (min_quantity) {
+            if (queryString) {
+                queryString += '&'
+            }
+            queryString += 'min_quantity=' + min_quantity
+        }
+        if (max_quantity) {
+            if (queryString) {
+                queryString += '&'
+            }
+            queryString += 'max_quantity=' + max_quantity
         }
 
         $("#item_flash_message").empty();

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -169,17 +169,49 @@ class TestShopCartsServer(TestCase):
         self._add_new_shopcart_item(CUSTOMER_ID, ITEM_ID, 1)
         self._add_new_shopcart_item(CUSTOMER_ID, 2, 10)
         self._add_new_shopcart_item(CUSTOMER_ID, 3, 10)
+        self._add_new_shopcart_item(CUSTOMER_ID, 5, 20)
+
         response = self.app.get(f'/shopcarts/{CUSTOMER_ID}/items?quantity=10')
         data = response.get_json()
         self.assertEqual(data['customer_id'], 1)
         self.assertEqual(len(data['items']), 2)
 
+        response = self.app.get(f'/shopcarts/{CUSTOMER_ID}/items?min_quantity=10')
+        data = response.get_json()
+        self.assertEqual(data['customer_id'], 1)
+        self.assertEqual(len(data['items']), 3)
+
+        response = self.app.get(f'/shopcarts/{CUSTOMER_ID}/items?max_quantity=10')
+        data = response.get_json()
+        self.assertEqual(data['customer_id'], 1)
+        self.assertEqual(len(data['items']), 3)
+
+        response = self.app.get(f'/shopcarts/{CUSTOMER_ID}/items?min_quantity=5&max_quantity=15')
+        data = response.get_json()
+        self.assertEqual(data['customer_id'], 1)
+        self.assertEqual(len(data['items']), 2)
+
+        response = self.app.get(f'/shopcarts/{CUSTOMER_ID}/items?quantity=10&min_quantity=1&max_quantity=100')
+        data = response.get_json()
+        self.assertEqual(data['customer_id'], 1)
+        self.assertEqual(len(data['items']), 2)
+
     def test_read_customer_shopcart_items_with_invalid_query(self):
-        """ It should return 400 if the query parameter value for quantity is invalid """
+        """ It should return 400 if the query parameter values for quantities are invalid """
         self._add_new_shopcart(CUSTOMER_ID)
         self._add_new_shopcart_item(CUSTOMER_ID, ITEM_ID, 1)
         self._add_new_shopcart_item(CUSTOMER_ID, 2, 10)
+
         response = self.app.get(f'/shopcarts/{CUSTOMER_ID}/items?quantity=abc')
+        self.assertEqual(response.status_code, 400)
+
+        response = self.app.get(f'/shopcarts/{CUSTOMER_ID}/items?min_quantity=abc')
+        self.assertEqual(response.status_code, 400)
+
+        response = self.app.get(f'/shopcarts/{CUSTOMER_ID}/items?max_quantity=abc')
+        self.assertEqual(response.status_code, 400)
+
+        response = self.app.get(f'/shopcarts/{CUSTOMER_ID}/items?min_quantity=5&max_quantity=2')
         self.assertEqual(response.status_code, 400)
 
     def test_update_item_quantity_positive(self):


### PR DESCRIPTION
Addresses issue #88 

ip:8080/shopcarts/10/items?quantity=3&min_quantity=1&max_quantity=2 - would ignore min and max quantities and just query for items with quantity=3
ip:8080/shopcarts/10/items?min_quantity=1 - query for items with quantity >= 1
ip:8080/shopcarts/10/items?max_quantity=2 - query for items with quantity <= 2
ip:8080/shopcarts/10/items?min_quantity=1&max_quantity=2 - query for items with quantity between 1 and 2.